### PR TITLE
CircleCi CLI should make authenticated GH requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ commands:
     - run:
         name: Validate orbs
         command: |
+            export GITHUB_TOKEN=$GH_TOKEN
             curl --http1.1 -fLSs https://circle.ci/cli | DESTDIR=~ bash
             ~/circleci > /dev/null # first run checks for updates
             find . -name orb.yml -print0 | xargs -0 -I% ~/circleci orb validate %


### PR DESCRIPTION
I've seen occasions where `circleci-cli` ran into the GH rate limit during the "validate orbs" step. In order to avoid this, it should be able to reuse the already existing GH token from the build environment.
