### PR TITLE
chore(test): add tests for testing monitoring script

### DIFF
--- a/.circleci/orbs/helix-post-deploy/orb.yml
+++ b/.circleci/orbs/helix-post-deploy/orb.yml
@@ -70,23 +70,23 @@ commands:
             type: string
             default: ""
             description: The URL to monitor in New Relic
-        newrelic_type: 
+        newrelic_type:
             type: string
             default: ""
             description: The type of monitor (api or browser)
-        newrelic_locations: 
+        newrelic_locations:
             type: string
             default: ""
             description: The comma-separated list of locations to use
-        newrelic_frequency: 
+        newrelic_frequency:
             type: integer
             default: 15
             description: The frequency to trigger the monitor in minutes
-        newrelic_script: 
+        newrelic_script:
             type: string
             default: ""
             description: The path to the custom monitor script to use
-        newrelic_group_policy: 
+        newrelic_group_policy:
             type: string
             default: ""
             description: A collective alert policy in New Relic to add the monitor to
@@ -133,7 +133,7 @@ commands:
               nrLocations="<< parameters.newrelic_locations >>"
               nrFrequency="<< parameters.newrelic_frequency >>"
               nrScript="<< parameters.newrelic_script >>"
-              nrGroupPolicy="<< parameters.newrelic_group_policy >>" 
+              nrGroupPolicy="<< parameters.newrelic_group_policy >>"
               spAuth="<< parameters.statuspage_auth >>"
               spName="<< parameters.statuspage_name >>"
               spGroup="<< parameters.statuspage_group >>"
@@ -158,7 +158,7 @@ commands:
                 actionVersion=`node -e "console.log(require('./package.json').version.match(/^[0-9]+/)[0])"`
                 nrURL="--url https://adobeioruntime.net/api/v1/web/${actionNS}/${actionPackage}/${actionName}@v${actionVersion}/_status_check/healthcheck.json"
               fi
-              if [ $aws = true ]; then
+              if [ "$aws" = true ]; then
                 nrURL="${nrURL} --url https://${awsApi:-${HLX_AWS_API}}.execute-api.${awsRegion:-${HLX_AWS_REGION}}.amazonaws.com/helix-services/word2md/v2/_status_check/healthcheck.json"
                 nrName="${nrName} --name ${nrName:-${actionName}}.aws"
               fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-ops",
-  "version": "2.0.0",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "nock": "13.0.6",
     "nyc": "15.1.0",
     "semantic-release": "17.3.7",
-    "sinon": "9.2.4"
+    "sinon": "9.2.4",
+    "yaml": "^1.10.0"
   },
   "lint-staged": {
     "*.js": "eslint"

--- a/test/monitoring/newrelic.js
+++ b/test/monitoring/newrelic.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+/* eslint-disable no-console */
+
+console.log(JSON.stringify(process.argv.slice(2), null, 2));

--- a/test/monitoring/specs/statuspage_name.json
+++ b/test/monitoring/specs/statuspage_name.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "statuspage_name": "foo"
+  },
+  "output": [
+    "setup",
+    "--url",
+    "https://adobeioruntime.net/api/v1/web///ops@v2/_status_check/healthcheck.json",
+    "--email",
+    "setup",
+    "--silent",
+    "--name",
+    "foo"
+  ]
+}

--- a/test/monitoring/statuspage.js
+++ b/test/monitoring/statuspage.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+/* eslint-disable no-console */
+
+console.log(process.argv.slice(2).join(' '));

--- a/test/testMonitoringSetup.js
+++ b/test/testMonitoringSetup.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+const assert = require('assert');
+const shell = require('shelljs');
+const fse = require('fs-extra');
+const path = require('path');
+const YAML = require('yaml');
+
+const MONITORING = path.resolve(__dirname, 'monitoring');
+
+function replaceThis(parameters, cmd, k) {
+  const s = cmd.replace(new RegExp(`<< parameters.${k} >>`), parameters[k]);
+  return s;
+}
+
+describe('Testing monitoring setup', () => {
+  let setup;
+  before(() => {
+    const orbConfigSource = fse.readFileSync(
+      path.resolve(__dirname, '../.circleci/orbs/helix-post-deploy/orb.yml'),
+      'utf8',
+    );
+    const orbConfig = YAML.parseDocument(orbConfigSource).toJSON();
+    setup = orbConfig.commands.monitoring.steps.find(
+      (step) => step.run.name === 'Monitoring Setup',
+    );
+  });
+  const specs = path.resolve(MONITORING, 'specs');
+  fse.readdirSync(specs).forEach((filename) => {
+    const name = filename.substring(0, filename.length - 5);
+    const { parameters, output } = fse.readJSONSync(path.resolve(specs, filename), 'utf8');
+    it(`Testing ${name}`, async () => {
+      const command = Object.keys(parameters).reduce(
+        (cmd, k) => cmd.replace(new RegExp(`<< parameters.${k} >>`), parameters[k]),
+        // (cmd, k) => replaceThis(parameters, cmd, k),
+        setup.run.command,
+      )
+        .replace(/<< parameters.tool_path >>/, MONITORING)
+        .replace(/<< .+ >>/g, '');
+      const { stdout } = shell.exec(command, { silent: true });
+      assert.deepStrictEqual(JSON.parse(stdout), output);
+    });
+  });
+});


### PR DESCRIPTION
Adds a test for running all tests specified by files in `monitoring/specs`.

For every file in that directory:
- It fills the parameters specified, leaves all others empty
- Runs the script in `.circleci/orbs/helix-post-deploy/orb.yml`, in `monitoring/steps/run[name='Monitoring Setup'`
- Compares the output to the one expected