### PR TITLE
chore(monitoring): add deprecated statuspage --aws argument back

### DIFF
--- a/src/statuspage/cli.js
+++ b/src/statuspage/cli.js
@@ -277,6 +277,12 @@ class CLI {
           describe: 'Reduce output to automation email only',
           required: false,
           default: false,
+        })
+        .option('aws', {
+          type: 'boolean',
+          describe: 'The action is also deployed in AWS (deprecated)',
+          required: false,
+          default: false,
         });
     }
     return yargs


### PR DESCRIPTION
In order to support pre helix-post-deploy@3.0.0 configs, `statuspage` should still acept a (noop) `aws` argument.