### PR TITLE
feat(monitoring): leave existing comp in its group

### DIFF
--- a/src/statuspage/cli.js
+++ b/src/statuspage/cli.js
@@ -129,7 +129,7 @@ class CLI {
       if (comp.description !== description) {
         component.description = description;
       }
-      if (group && comp.group_id !== group.id) {
+      if (group && !comp.group_id) {
         component.group_id = group.id;
       }
       if (Object.keys(component).length > 0) {

--- a/test/testStatuspage.js
+++ b/test/testStatuspage.js
@@ -273,7 +273,7 @@ describe('Testing statuspage', function testStatuspage() {
       .start();
 
     await run(cliConfig({ group }));
-    assert.ok(await getTimedPromise(() => compUpdated, 'Component not added to group'));
+    assert.ok(await getTimedPromise(() => compUpdated, 'Component added to group'));
     api.stop();
   });
 

--- a/test/testStatuspage.js
+++ b/test/testStatuspage.js
@@ -258,6 +258,25 @@ describe('Testing statuspage', function testStatuspage() {
     api.stop();
   });
 
+  it('leaves existing component in existing group', async () => {
+    let compUpdated = false;
+    const api = new StatuspageAPI(apiConfig({
+      new: false,
+      component: {
+        ...component,
+        group_id: '0001',
+      },
+    }))
+      .on(StatuspageAPI.UPDATE_COMPONENT, (uri, req) => {
+        compUpdated = req.component && !req.component.group_id;
+      })
+      .start();
+
+    await run(cliConfig({ group }));
+    assert.ok(await getTimedPromise(() => compUpdated, 'Component not added to group'));
+    api.stop();
+  });
+
   it('outputs only email in silent mode', async () => {
     let compCreated = false;
 


### PR DESCRIPTION
Fix #239 